### PR TITLE
chore(logging): disable all loggers by setting root level to OFF

### DIFF
--- a/pricefetcherservice/src/test/resources/logback.xml
+++ b/pricefetcherservice/src/test/resources/logback.xml
@@ -1,0 +1,9 @@
+<configuration>
+    <!-- Production Environment : ERROR/WARN-->
+    <!-- Development Environment : DEBUG/INFO-->
+
+    <!-- Disable all loggers-->
+    <root level="OFF">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>


### PR DESCRIPTION
- Updated logging configuration to set the root logger level to OFF.
- This change disables all loggers to prevent unnecessary log output.
- Added comments to guide setting log levels for production (ERROR/WARN) and development (DEBUG/INFO).